### PR TITLE
AzureGeneratedSecrets for APIM

### DIFF
--- a/v2/api/apimanagement/customizations/subscription_extensions.go
+++ b/v2/api/apimanagement/customizations/subscription_extensions.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package customizations
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	apimanagement "github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801storage"
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	. "github.com/Azure/azure-service-operator/v2/internal/logging"
+	"github.com/Azure/azure-service-operator/v2/internal/util/to"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
+)
+
+var _ genruntime.KubernetesExporter = &SubscriptionExtension{}
+
+func (ext *SubscriptionExtension) ExportKubernetesResources(
+	ctx context.Context,
+	obj genruntime.MetaObject,
+	armClient *genericarmclient.GenericClient,
+	log logr.Logger,
+) ([]client.Object, error) {
+
+	// This has to be the current hub storage version. It will need to be updated
+	// if the hub storage version changes.
+	typedObj, ok := obj.(*apimanagement.Subscription)
+	if !ok {
+		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *apimanagement.Subscription", obj)
+	}
+
+	// Type assert that we are the hub type. This will fail to compile if
+	// the hub type has been changed but this extension has not
+	var _ conversion.Hub = typedObj
+
+	hasSecrets := secretsSpecified(typedObj)
+	if !hasSecrets {
+		log.V(Debug).Info("No secrets retrieval to perform as operatorSpec is empty")
+		return nil, nil
+	}
+
+	id, err := genruntime.GetAndParseResourceID(typedObj)
+	if err != nil {
+		return nil, err
+	}
+
+	if id.Parent == nil {
+		return nil, errors.Errorf("APIM subscription had no parent ID: %s", id.String())
+	}
+	parentName := id.Parent.Name
+
+	// Only bother calling ListSecrets if there are secrets to retrieve
+	var s armapimanagement.SubscriptionKeysContract
+	if hasSecrets {
+		subscription := id.SubscriptionID
+		// Using armClient.ClientOptions() here ensures we share the same HTTP connection, so this is not opening a new
+		// connection each time through
+		var subClient *armapimanagement.SubscriptionClient
+		subClient, err = armapimanagement.NewSubscriptionClient(subscription, armClient.Creds(), armClient.ClientOptions())
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create new SubscriptionClient")
+		}
+
+		var resp armapimanagement.SubscriptionClientListSecretsResponse
+		resp, err = subClient.ListSecrets(ctx, id.ResourceGroupName, parentName, typedObj.AzureName(), nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed listing secrets")
+		}
+
+		s = resp.SubscriptionKeysContract
+	}
+
+	secretSlice, err := secretsToWrite(typedObj, s)
+	if err != nil {
+		return nil, err
+	}
+
+	return secrets.SliceToClientObjectSlice(secretSlice), nil
+}
+
+func secretsSpecified(obj *apimanagement.Subscription) bool {
+	if obj.Spec.OperatorSpec == nil || obj.Spec.OperatorSpec.Secrets == nil {
+		return false
+	}
+
+	hasSecrets := false
+	secrets := obj.Spec.OperatorSpec.Secrets
+	if secrets.PrimaryKey != nil || secrets.SecondaryKey != nil {
+		hasSecrets = true
+	}
+
+	return hasSecrets
+}
+
+func secretsToWrite(obj *apimanagement.Subscription, s armapimanagement.SubscriptionKeysContract) ([]*v1.Secret, error) {
+	operatorSpecSecrets := obj.Spec.OperatorSpec.Secrets
+	if operatorSpecSecrets == nil {
+		return nil, errors.Errorf("unexpected nil operatorspec")
+	}
+
+	collector := secrets.NewCollector(obj.Namespace)
+	collector.AddValue(operatorSpecSecrets.PrimaryKey, to.Value(s.PrimaryKey))
+	collector.AddValue(operatorSpecSecrets.SecondaryKey, to.Value(s.SecondaryKey))
+
+	return collector.Values()
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement v1.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration v1.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos v1.0.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1 h1:LNHhpdK7hzUcx/k1LIcuh
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1/go.mod h1:uE9zaUfEQT/nbQjVi2IblCG9iaLtZsuYZ8ne+PuQ02M=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement v1.1.1 h1:jCkNVNpsEevyic4bmjgVjzVA4tMGSJpXNGirf+S+mDI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement v1.1.1/go.mod h1:a0Ug1l73Il7EhrCJEEt2dGjlNjvphppZq5KqJdgnwuw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration v1.1.1 h1:iRc20pGuVlc1HwRO2bg0m1tfP9rkPB0K88trl8Fei2w=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration v1.1.1/go.mod h1:21Lewei+tg5zp5xmyOxfDY//2tBvWQXee0UoM8xZjr8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0 h1:figxyQZXzZQIcP3njhC68bYUiTw45J8/SsHaLW8Ax0M=


### PR DESCRIPTION
Can retarget this to a different branch if this branch merges first.

**This still needs tests**. Specifically, in the subscription test we should set the `operatorSpec.Secrets.PrimaryKey` to a k8s secret, run the test, and ensure that we actually do the right thing and call the secrets API with the right value and flow it to the kubernetes secret.

There are example tests that already do this in for example storageAccount (and many others)

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
